### PR TITLE
feat(ci): setup GitHub Actions for deploying to GitHub Pages

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -1,0 +1,47 @@
+name: Deploy to GitHub Pages
+
+on:
+  push:
+    branches:
+      - main # mainブランチへのpush時に実行
+  workflow_dispatch: # 手動実行も可能にする
+
+permissions:
+  contents: read
+  pages: write
+  id-token: write
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4 # バージョン: v4
+
+      - name: Setup Node.js
+        uses: actions/setup-node@v4 # バージョン: v4
+        with:
+          node-version-file: '.nvmrc' # .nvmrcからNode.jsバージョンを読み込む
+          cache: 'npm'
+
+      - name: Install dependencies
+        run: npm ci
+
+      - name: Build Next.js application
+        run: npm run build
+
+      - name: Upload artifact
+        uses: actions/upload-pages-artifact@v3 # バージョン: v3
+        with:
+          path: ./out
+
+  deploy:
+    needs: build
+    runs-on: ubuntu-latest
+    environment:
+      name: github-pages
+      url: ${{ steps.deployment.outputs.page_url }}
+    steps:
+      - name: Deploy to GitHub Pages
+        id: deployment
+        uses: actions/deploy-pages@v4 # バージョン: v4

--- a/next.config.ts
+++ b/next.config.ts
@@ -1,7 +1,12 @@
-import type { NextConfig } from "next";
+import type { NextConfig } from 'next'
+
+const isGithubActions = process.env.GITHUB_ACTIONS === 'true'
 
 const nextConfig: NextConfig = {
   /* config options here */
-};
+  output: 'export',
+  basePath: isGithubActions ? '/archero2-lab' : '',
+  assetPrefix: isGithubActions ? '/archero2-lab/' : '',
+}
 
-export default nextConfig;
+export default nextConfig


### PR DESCRIPTION
## Overview

This pull request establishes the CI/CD pipeline for the project by leveraging GitHub Actions. It fully automates the process of building the Next.js application and deploying it as a static site to GitHub Pages.

This corresponds to the completion of Phase 2 of the initial project setup.

## Changes

- **GitHub Actions Workflow:**
  - A new workflow file `.github/workflows/deploy.yml` has been added.
  - The workflow triggers on every push to the `main` branch.
  - It consists of two jobs: `build` and `deploy`.
    - The `build` job checks out the code, sets up the Node.js environment based on `.nvmrc`, installs dependencies using `npm ci`, and runs `npm run build` to generate the static export.
    - The `deploy` job takes the build artifact and deploys it to GitHub Pages.

- **Next.js Configuration:**
  - The `next.config.mjs` has been updated to set the `basePath` and `assetPrefix` dynamically. This is crucial for ensuring that all asset paths are resolved correctly under the GitHub Pages subdirectory (`/<repository-name>/`).

- **Repository Settings (Manual Steps Required):**
  - Workflow permissions have been set to `Read and write permissions`.
  - The deployment source for GitHub Pages has been configured to `GitHub Actions`.

## Verification

After this PR is merged into `main`, the `Deploy to GitHub Pages` action should run automatically and succeed. The live site should then be accessible and fully functional at the designated GitHub Pages URL, with no broken styles or assets.

## Related Issues

- None